### PR TITLE
Add new entity tor the Root Group of Tasks

### DIFF
--- a/lib/App/Please/DirContent.pm
+++ b/lib/App/Please/DirContent.pm
@@ -1,0 +1,17 @@
+package App::Please::DirContent;
+use v5.10;
+use strict;
+use warnings;
+use autodie;
+
+sub get {
+    my ($class, $path) = @_;
+
+    opendir my ($dh), $path;
+    my @contents = grep { $_ ne '.' && $_ ne '..' } readdir $dh;
+    closedir $dh;
+
+    return \@contents;
+}
+
+1;

--- a/lib/App/Please/Group.pm
+++ b/lib/App/Please/Group.pm
@@ -5,6 +5,8 @@ use warnings;
 use autodie;
 
 use File::Basename;
+
+use App::Please::DirContent;
 use App::Please::Task;
 
 sub new {
@@ -12,16 +14,22 @@ sub new {
 
     return undef unless (-d $path);
 
+    my $content = App::Please::DirContent->get($path);
+
     my $self = {
         name => basename($path),
         path => $path,
-        content => $class->_get_content($path),
+        groups => [
+            grep { $_ }
+            map { App::Please::Group->new("$path/$_") } @$content
+        ],
+        tasks => [
+            grep { $_ }
+            map { App::Please::Task->new("$path/$_") } @$content
+        ],
     };
 
     bless $self, $class;
-
-    $self->{groups} = $self->_get_groups();
-    $self->{tasks} = $self->_get_tasks();
 
     # Empty groups are not groups
     return @{$self->groups} || @{$self->tasks} ? $self : undef;
@@ -31,55 +39,5 @@ sub name { shift->{name} }
 sub path { shift->{path} }
 sub groups { shift->{groups} }
 sub tasks { shift->{tasks} }
-sub is_empty { return ! @{ $_[0]->groups || $_[0]->tasks || [] } }
-
-sub get_task {
-    my ($self, $task) = @_;
-
-    my @namespaces = split('/', $task);
-    my $task_name = pop @namespaces;
-
-    my $group = $self;
-    while (@namespaces) {
-        my $next_group = shift @namespaces;
-
-        $group = (grep {$_->name eq $next_group } @{$group->groups})[0];
-        return undef unless $group;
-    }
-
-    return (grep {$_->name eq $task_name} @{$group->tasks})[0];
-}
-
-sub _get_content {
-    my ($class, $path) = @_;
-
-    opendir my ($dh), $path;
-    my @contents = grep { $_ ne '.' && $_ ne '..' } readdir $dh;
-    closedir $dh;
-
-    return \@contents;
-}
-
-sub _get_groups {
-    my $self = shift;
-
-    return [
-        grep { $_ }
-        map {
-            App::Please::Group->new($self->path . "/$_")
-        } @{ $self->{content} }
-    ];
-}
-
-sub _get_tasks {
-    my $self = shift;
-
-    return [
-        grep { $_ }
-        map {
-            App::Please::Task->new($self->path . "/$_")
-        } @{ $self->{content} }
-    ];
-}
 
 1;

--- a/lib/App/Please/Root.pm
+++ b/lib/App/Please/Root.pm
@@ -1,0 +1,56 @@
+package App::Please::Root;
+use v5.10;
+use strict;
+use warnings;
+use autodie;
+
+use App::Please::DirContent;
+use App::Please::Task;
+use App::Please::Group;
+
+sub new {
+    my ($class, $path) = @_;
+
+    die "$path does not exists" unless -d $path;
+
+    my $content = App::Please::DirContent->get($path);
+
+    my $self = {
+        groups => [
+            grep { $_ }
+            map { App::Please::Group->new("$path/$_") } @$content
+        ],
+        tasks => [
+            grep { $_ }
+            map { App::Please::Task->new("$path/$_") } @$content
+        ],
+    };
+
+    bless $self, $class;
+
+    return $self;
+}
+
+sub groups { shift->{groups} }
+sub tasks { shift->{tasks} }
+sub is_empty { return ! @{ $_[0]->groups || $_[0]->tasks || [] } }
+
+sub get_task {
+    my ($self, $task) = @_;
+
+    my @namespaces = split('/', $task);
+    my $task_name = pop @namespaces;
+
+    my $group = $self;
+    while (@namespaces) {
+        my $next_group = shift @namespaces;
+
+        $group = (grep {$_->name eq $next_group } @{$group->groups})[0];
+        return undef unless $group;
+    }
+
+    return (grep {$_->name eq $task_name} @{$group->tasks})[0];
+}
+
+1;
+

--- a/t/App/Please/Group.t
+++ b/t/App/Please/Group.t
@@ -20,17 +20,12 @@ subtest 'On empty directory' => sub {
 };
 
 subtest 'On non-empty directory' => sub {
-    my $scenario = 't/scenarios/1/tasks';
+    my $scenario = 't/scenarios/1/tasks/config';
     my $group;
 
     ok($group = CLASS->new($scenario), 'new() returns an object');
     isa_ok($group, CLASS, 'group');
-
-    ok($group->get_task('work'), 'has "work" task');
-    ok($group->get_task('config/file'), 'has "config/file" task');
-
-    ok(! $group->get_task('not-work'), 'has no "not-worwork" task (! -X)');
-    ok(! $group->get_task('non-existant'), 'has no "non-existant" task (! -e)');
+    is($group->name, 'config');
 };
 
 done_testing;

--- a/t/App/Task/Root.t
+++ b/t/App/Task/Root.t
@@ -1,0 +1,42 @@
+#!/usr/bin/env perl
+use v5.10;
+use strict;
+use warnings;
+use File::Temp qw/tempdir/;
+use Test::More;
+
+use constant CLASS => 'App::Please::Root';
+use_ok(CLASS);
+
+subtest 'On non existing directory' => sub {
+    eval {
+        CLASS->new('non-existing-dir');
+    };
+    like($@, qr/does not exists/, 'new() raises an error');
+};
+
+subtest 'On empty directory' => sub {
+    my $empty_dir = File::Temp->newdir(CLEANUP => 1);
+
+    ok(my $root = CLASS->new($empty_dir), 'new() returns an object');
+    isa_ok($root, CLASS, 'root');
+
+    ok($root->is_empty, 'is empty');
+};
+
+subtest 'On non-empty directory' => sub {
+    my $scenario = 't/scenarios/1/tasks';
+
+    ok(my $root = CLASS->new($scenario), 'new() returns an object');
+    isa_ok($root, CLASS, 'root');
+
+    isnt($root->is_empty, 'is not empty');
+
+    ok($root->get_task('work'), 'has "work" task');
+    ok($root->get_task('config/file'), 'has "config/file" task');
+
+    ok(! $root->get_task('not-work'), 'has no "not-work" task (! -X)');
+    ok(! $root->get_task('non-existant'), 'has no "non-existant" task (! -e)');
+};
+
+done_testing;


### PR DESCRIPTION
This new entity aggregates all their nested Groups and Tasks and acts as
a single entry point for operations on the forementioned elements.

Doing this, we're releaving Group for some of their old
responsabilities.

Closes #7 